### PR TITLE
chore(deps): bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: .github/cliff.toml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -51,12 +51,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -69,12 +69,12 @@ jobs:
           uv run pytest tests/ -v -m "not e2e" --cov=vcluster_argocd_enroller --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: always()
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
           helm push "vcluster-argocd-enroller-${CHART_VERSION}.tgz" oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
 
       - name: Create Helm chart artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: helm-chart
           path: vcluster-argocd-enroller-*.tgz


### PR DESCRIPTION
## Summary

Consolidates 5 dependabot PRs (#3, #4, #6, #7, #9) into a single update:

- `actions/setup-python` v5 → v6
- `astral-sh/setup-uv` v3 → v7
- `codecov/codecov-action` v4 → v5 (renamed `file` → `files` input)
- `actions/upload-artifact` v4 → v7
- `orhun/git-cliff-action` v3 → v4

Closes #3, closes #4, closes #6, closes #7, closes #9.

## Test plan

- [ ] CI lint, test, build, helm-lint, validate, and security jobs pass
- [ ] Integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)