### PR TITLE
docs: add CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --status in_progress  # Claim work
+bd close <id>         # Complete work
+bd sync               # Sync with git
+```
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd sync
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,29 +12,18 @@ bd close <id>         # Complete work
 bd sync               # Sync with git
 ```
 
-## Landing the Plane (Session Completion)
+## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+When ending a work session, complete ALL steps below. Work is NOT complete until `git push` succeeds.
 
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+1. File issues for remaining work
+2. Run quality gates if code changed (tests, linters, builds)
+3. Update issue status — close finished work, update in-progress items
+4. Push to remote:
    ```bash
    git pull --rebase
    bd sync
    git push
-   git status  # MUST show "up to date with origin"
+   git status  # Must show "up to date with origin"
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-
+5. Clean up — clear stashes, prune remote branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Kopf-based Kubernetes operator (Python) that watches for vCluster StatefulSets (label `app=vcluster`) and automatically creates/deletes corresponding ArgoCD cluster secrets. The operator extracts TLS credentials from vCluster secrets (`vc-{name}`) and creates ArgoCD-compatible cluster secrets (`vcluster-{name}`) in the `argocd` namespace.
+A Kopf-based Kubernetes operator (Python) that watches for vCluster StatefulSets (label `app=vcluster`) and automatically creates/deletes corresponding ArgoCD cluster secrets. The operator extracts TLS credentials from vCluster secrets (`vc-{name}`) and creates ArgoCD-compatible cluster secrets (`vcluster-{name}`) in a configurable ArgoCD namespace.
 
 ## Build & Dev Commands
 
@@ -22,7 +22,7 @@ task helm-template                   # Render templates
 
 ```bash
 uv run pytest tests/ -v                                          # All tests
-uv run pytest tests/ -v -m "not integration"                     # Skip integration
+uv run pytest tests/ -v -m "not e2e"                             # Skip e2e (CI default)
 uv run pytest tests/ -k test_name -v -s                          # Single test
 uv run pytest tests/ --cov=vcluster_argocd_enroller --cov-report=term-missing  # Coverage
 ```
@@ -35,15 +35,15 @@ Pre-commit runs ruff (lint + format), mypy, and hadolint. Config: `line-length=1
 
 ## Architecture
 
-- **`src/vcluster_argocd_enroller/operator.py`** — Core logic. Kopf handlers for `@kopf.on.create`, `@kopf.on.resume`, `@kopf.on.delete` on StatefulSets. Module-level K8s client init (in-cluster vs kubeconfig). `ARGOCD_NAMESPACE` is hardcoded to `"argocd"`.
-- **`src/vcluster_argocd_enroller/cli.py`** — Cyclopts CLI. `run` (default) launches kopf via `sys.argv` manipulation. Also: `check`, `enroll`, `unenroll`, `test` subcommands.
-- **`src/vcluster_argocd_enroller/__init__.py`** — Exports handlers, defines `__version__`.
-- **`helm/vcluster-argocd-enroller/`** — Helm chart. Deploys as a Deployment with ClusterRole for secrets + statefulsets RBAC. Has an `useEmbeddedCode` toggle (true=run installed package, false=mount operator.py from ConfigMap).
-- **Tests** — `test_operator_integration.py` mocks K8s API via `unittest.mock.patch` on module-level clients. `test_e2e.py` needs a live cluster.
+- **`src/vcluster_argocd_enroller/operator.py`** — Core logic. Kopf handlers (`@kopf.on.create`, `@kopf.on.resume`, `@kopf.on.update`, `@kopf.on.delete`) on StatefulSets with `app=vcluster` label. Uses lazy K8s client init via `_ensure_k8s()` (safe to import without a kubeconfig). `ARGOCD_NAMESPACE` read from env var (default `"argocd"`). Create-or-update is idempotent (catches 409 Conflict, falls back to `replace_namespaced_secret`).
+- **`src/vcluster_argocd_enroller/cli.py`** — Cyclopts CLI. `run` (default) launches kopf with `--liveness=http://0.0.0.0:8080/healthz` and `--all-namespaces`. Also: `check`, `enroll`, `unenroll` subcommands.
+- **`src/vcluster_argocd_enroller/__init__.py`** — Exports `__version__` only. No eager imports.
+- **`helm/vcluster-argocd-enroller/`** — Helm chart. Deploys as a Deployment with ClusterRole for secrets + statefulsets RBAC. Probes hit kopf's `/healthz` on port 8080.
+- **Tests** — `test_operator_integration.py` uses lazy-init fixtures that pre-set `_k8s_configured`/`_core_v1_api`/`_apps_v1_api` globals. `test_e2e.py` needs a live cluster.
 
 ## CI/CD (GitHub Actions)
 
-- **ci.yaml** — Lint, test (Python 3.12+3.13), docker build+Trivy, helm lint, kubeconform validation, k3d integration test on PRs.
+- **ci.yaml** — Lint, test (Python 3.13), docker build+Trivy, helm lint, kubeconform validation, k3d integration test on PRs.
 - **release.yaml** — Triggered by `v*` tags. Builds multi-arch (amd64/arm64) image, pushes to `ghcr.io`. Packages Helm chart to `oci://ghcr.io/{owner}/charts/`.
 - **dev.yaml** — Pushes `edge`/branch-tagged images on main/develop push.
 
@@ -53,3 +53,4 @@ Pre-commit runs ruff (lint + format), mypy, and hadolint. Config: `line-length=1
 - The operator uses `kopf.TemporaryError(delay=60)` for retryable failures and `kopf.PermanentError` for non-retryable ones.
 - Deletion handlers never raise PermanentError (to avoid blocking finalizer removal).
 - Helm chart deploys into `operator.vclusterNamespace` (default: `vcluster-system`), not a separate operator namespace.
+- Python >= 3.13 required. Docker base image: `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A Kopf-based Kubernetes operator (Python) that watches for vCluster StatefulSets (label `app=vcluster`) and automatically creates/deletes corresponding ArgoCD cluster secrets. The operator extracts TLS credentials from vCluster secrets (`vc-{name}`) and creates ArgoCD-compatible cluster secrets (`vcluster-{name}`) in the `argocd` namespace.
+
+## Build & Dev Commands
+
+```bash
+uv sync                              # Install dependencies
+uv sync --all-extras                  # Install with dev deps
+uv run vcluster-argocd-enroller      # Run operator
+uv run vcluster-argocd-enroller --dev --verbose  # Dev mode
+task build                           # Docker build
+task helm-lint                       # Lint Helm chart
+task helm-template                   # Render templates
+```
+
+## Testing
+
+```bash
+uv run pytest tests/ -v                                          # All tests
+uv run pytest tests/ -v -m "not integration"                     # Skip integration
+uv run pytest tests/ -k test_name -v -s                          # Single test
+uv run pytest tests/ --cov=vcluster_argocd_enroller --cov-report=term-missing  # Coverage
+```
+
+Markers: `integration`, `e2e` (requires real cluster), `slow`, `cli`, `operator`.
+
+## Linting
+
+Pre-commit runs ruff (lint + format), mypy, and hadolint. Config: `line-length=120`, `target-version="py313"`, ruff selects `E,F,I,N,W`.
+
+## Architecture
+
+- **`src/vcluster_argocd_enroller/operator.py`** — Core logic. Kopf handlers for `@kopf.on.create`, `@kopf.on.resume`, `@kopf.on.delete` on StatefulSets. Module-level K8s client init (in-cluster vs kubeconfig). `ARGOCD_NAMESPACE` is hardcoded to `"argocd"`.
+- **`src/vcluster_argocd_enroller/cli.py`** — Cyclopts CLI. `run` (default) launches kopf via `sys.argv` manipulation. Also: `check`, `enroll`, `unenroll`, `test` subcommands.
+- **`src/vcluster_argocd_enroller/__init__.py`** — Exports handlers, defines `__version__`.
+- **`helm/vcluster-argocd-enroller/`** — Helm chart. Deploys as a Deployment with ClusterRole for secrets + statefulsets RBAC. Has an `useEmbeddedCode` toggle (true=run installed package, false=mount operator.py from ConfigMap).
+- **Tests** — `test_operator_integration.py` mocks K8s API via `unittest.mock.patch` on module-level clients. `test_e2e.py` needs a live cluster.
+
+## CI/CD (GitHub Actions)
+
+- **ci.yaml** — Lint, test (Python 3.12+3.13), docker build+Trivy, helm lint, kubeconform validation, k3d integration test on PRs.
+- **release.yaml** — Triggered by `v*` tags. Builds multi-arch (amd64/arm64) image, pushes to `ghcr.io`. Packages Helm chart to `oci://ghcr.io/{owner}/charts/`.
+- **dev.yaml** — Pushes `edge`/branch-tagged images on main/develop push.
+
+## Key Conventions
+
+- Version is tracked in three places: `__init__.py`, `pyproject.toml`, `Chart.yaml` (CI updates Chart.yaml at release time via sed).
+- The operator uses `kopf.TemporaryError(delay=60)` for retryable failures and `kopf.PermanentError` for non-retryable ones.
+- Deletion handlers never raise PermanentError (to avoid blocking finalizer removal).
+- Helm chart deploys into `operator.vclusterNamespace` (default: `vcluster-system`), not a separate operator namespace.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project guidance for Claude Code — accurately reflects the 1.0.0 codebase (lazy K8s init, env-based ARGOCD_NAMESPACE, idempotent create-or-update, kopf health probes, Python 3.13 only, no ConfigMap toggle)
- Add `AGENTS.md` with beads issue tracking workflow and session completion checklist

## Test plan

- [ ] CI passes (docs only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)