### PR TITLE
docs: reorient README for users, move dev docs to BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,136 @@
+# vCluster ArgoCD Enroller
+
+A Kubernetes operator with CLI that automatically enrolls vCluster instances in ArgoCD for GitOps management.
+
+## Overview
+
+This operator watches for vCluster StatefulSets and automatically:
+1. Extracts the vCluster kubeconfig from its secret
+2. Creates an ArgoCD cluster secret with proper authentication
+3. Cleans up ArgoCD secrets when vClusters are deleted
+
+## Setup
+
+### Prerequisites
+
+- Python 3.13+
+- `uv` package manager
+- Kubernetes cluster with ArgoCD installed
+- vCluster CLI (optional, for testing)
+
+### Installation
+
+```bash
+# Install with uv
+uv sync
+
+# Or install as editable package
+uv pip install -e .
+```
+
+### CLI Usage
+
+```bash
+# Run the operator
+uv run vcluster-argocd-enroller
+
+# Run in development mode with auto-reload
+uv run vcluster-argocd-enroller --dev --verbose
+
+# Check vCluster enrollment status
+uv run vcluster-argocd-enroller check
+
+# Manually enroll a vCluster
+uv run vcluster-argocd-enroller enroll my-vcluster --namespace vcluster-ns
+
+# Remove a vCluster from ArgoCD
+uv run vcluster-argocd-enroller unenroll my-vcluster --confirm
+
+# Run with specific namespace watching
+uv run vcluster-argocd-enroller --namespace my-namespace
+
+# Get help
+uv run vcluster-argocd-enroller --help
+```
+
+### Quick Development
+
+```bash
+# Install dependencies and run in dev mode
+uv sync
+uv run vcluster-argocd-enroller --dev --verbose
+```
+
+### Testing
+
+```bash
+# Run unit tests
+uv run pytest
+
+# Run unit tests with coverage
+uv run pytest --cov=vcluster_argocd_enroller
+
+# Run e2e tests (requires real cluster)
+uv run pytest -m e2e
+
+# Check existing vClusters
+uv run vcluster-argocd-enroller check --show-secrets
+```
+
+### Building Docker Image
+
+```bash
+task build
+```
+
+## How It Works
+
+The operator monitors StatefulSets with the label `app: vcluster` and:
+
+1. **On Create/Resume**:
+   - Extracts kubeconfig from secret `vc-{vcluster-name}`
+   - Creates ArgoCD cluster secret in `argocd` namespace
+   - Secret contains cluster endpoint and TLS certificates
+
+2. **On Delete**:
+   - Removes the corresponding ArgoCD cluster secret
+   - Cleans up gracefully even if secret doesn't exist
+
+## Configuration
+
+The operator expects:
+- vCluster secrets named: `vc-{vcluster-name}`
+- ArgoCD installed in namespace: `argocd`
+- vCluster StatefulSets labeled with: `app=vcluster`
+
+## Development
+
+This project uses:
+- `uv` for Python dependency management
+- `kopf` as the Kubernetes operator framework
+- `ruff` for linting and formatting
+
+### Project Structure
+
+```
+vcluster-argocd-enroller/
+├── src/
+│   └── vcluster_argocd_enroller/
+│       ├── __init__.py       # Package initialization
+│       ├── __main__.py       # Package entry point
+│       ├── cli.py            # Cyclopts CLI implementation
+│       └── operator.py       # Kopf operator logic
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py          # Pytest fixtures
+│   ├── test_operator_integration.py  # Unit tests with mocked K8s
+│   └── test_e2e.py          # End-to-end tests (requires cluster)
+├── pyproject.toml            # Python project configuration (uv)
+├── uv.lock                   # Locked dependencies
+├── pytest.ini                # Pytest configuration
+├── Taskfile.yml              # Task automation
+├── Dockerfile                # Container image definition
+├── .gitignore                # Git ignore rules
+├── README.md                 # User/operator guide
+└── BUILDING.md               # This file
+```

--- a/README.md
+++ b/README.md
@@ -1,135 +1,106 @@
 # vCluster ArgoCD Enroller
 
-A Kubernetes operator with CLI that automatically enrolls vCluster instances in ArgoCD for GitOps management.
+[![CI](https://github.com/andrewrothstein/vcluster-argocd-enroller/actions/workflows/ci.yaml/badge.svg)](https://github.com/andrewrothstein/vcluster-argocd-enroller/actions/workflows/ci.yaml)
+[![License](https://img.shields.io/github/license/andrewrothstein/vcluster-argocd-enroller)](https://github.com/andrewrothstein/vcluster-argocd-enroller/blob/main/LICENSE)
 
-## Overview
-
-This operator watches for vCluster StatefulSets and automatically:
-1. Extracts the vCluster kubeconfig from its secret
-2. Creates an ArgoCD cluster secret with proper authentication
-3. Cleans up ArgoCD secrets when vClusters are deleted
-
-## Setup
-
-### Prerequisites
-
-- Python 3.13+
-- `uv` package manager
-- Kubernetes cluster with ArgoCD installed
-- vCluster CLI (optional, for testing)
-
-### Installation
-
-```bash
-# Install with uv
-uv sync
-
-# Or install as editable package
-uv pip install -e .
-```
-
-### CLI Usage
-
-```bash
-# Run the operator
-uv run vcluster-argocd-enroller
-
-# Run in development mode with auto-reload
-uv run vcluster-argocd-enroller --dev --verbose
-
-# Check vCluster enrollment status
-uv run vcluster-argocd-enroller check
-
-# Manually enroll a vCluster
-uv run vcluster-argocd-enroller enroll my-vcluster --namespace vcluster-ns
-
-# Remove a vCluster from ArgoCD
-uv run vcluster-argocd-enroller unenroll my-vcluster --confirm
-
-# Run with specific namespace watching
-uv run vcluster-argocd-enroller --namespace my-namespace
-
-# Get help
-uv run vcluster-argocd-enroller --help
-```
-
-### Quick Development
-
-```bash
-# Install dependencies and run in dev mode
-uv sync
-uv run vcluster-argocd-enroller --dev --verbose
-```
-
-### Testing
-
-```bash
-# Run unit tests
-uv run pytest
-
-# Run unit tests with coverage
-uv run pytest --cov=vcluster_argocd_enroller
-
-# Run e2e tests (requires real cluster)
-uv run pytest -m e2e
-
-# Check existing vClusters
-uv run vcluster-argocd-enroller check --show-secrets
-```
-
-### Building Docker Image
-
-```bash
-task build
-```
+A Kubernetes operator that automatically enrolls [vCluster](https://www.vcluster.com/) instances in [ArgoCD](https://argo-cd.readthedocs.io/) for GitOps management.
 
 ## How It Works
 
-The operator monitors StatefulSets with the label `app: vcluster` and:
+The operator watches for vCluster StatefulSets (labeled `app=vcluster`) across your cluster. When a vCluster is created or updated, it:
 
-1. **On Create/Resume**:
-   - Extracts kubeconfig from secret `vc-{vcluster-name}`
-   - Creates ArgoCD cluster secret in `argocd` namespace
-   - Secret contains cluster endpoint and TLS certificates
+1. Reads the TLS credentials from the vCluster secret (`vc-{name}`)
+2. Creates an ArgoCD-compatible cluster secret (`vcluster-{name}`) in the ArgoCD namespace
+3. Cleans up the ArgoCD secret when the vCluster is deleted
 
-2. **On Delete**:
-   - Removes the corresponding ArgoCD cluster secret
-   - Cleans up gracefully even if secret doesn't exist
+This lets ArgoCD immediately discover and deploy to new vClusters without manual cluster registration.
+
+## Prerequisites
+
+- Kubernetes cluster (1.19+)
+- [ArgoCD](https://argo-cd.readthedocs.io/en/stable/getting_started/) installed
+- [vCluster](https://www.vcluster.com/docs/getting-started/setup) instances deployed with default naming conventions
+
+## Quick Start
+
+Install via Helm from the OCI registry:
+
+```bash
+helm install vcluster-argocd-enroller \
+  oci://ghcr.io/andrewrothstein/charts/vcluster-argocd-enroller \
+  --namespace vcluster-system \
+  --create-namespace
+```
+
+The operator will immediately begin watching for vCluster StatefulSets and creating the corresponding ArgoCD cluster secrets.
 
 ## Configuration
 
-The operator expects:
-- vCluster secrets named: `vc-{vcluster-name}`
-- ArgoCD installed in namespace: `argocd`
-- vCluster StatefulSets labeled with: `app=vcluster`
+Key Helm values:
 
-## Development
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `operator.argoCDNamespace` | ArgoCD namespace | `argocd` |
+| `operator.vclusterNamespace` | Namespace for vCluster instances | `vcluster-system` |
+| `operator.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `128Mi` |
+| `resources.limits.cpu` | CPU limit | `200m` |
+| `resources.limits.memory` | Memory limit | `256Mi` |
 
-This project uses:
-- `uv` for Python dependency management
-- `kopf` as the Kubernetes operator framework
-- `ruff` for linting and formatting
+Example with custom values:
 
-### Project Structure
-
+```bash
+helm install vcluster-argocd-enroller \
+  oci://ghcr.io/andrewrothstein/charts/vcluster-argocd-enroller \
+  --namespace vcluster-system \
+  --create-namespace \
+  --set operator.argoCDNamespace=argocd \
+  --set operator.logLevel=DEBUG
 ```
-vcluster-argocd-enroller/
-├── src/
-│   └── vcluster_argocd_enroller/
-│       ├── __init__.py       # Package initialization
-│       ├── __main__.py       # Package entry point
-│       ├── cli.py            # Cyclopts CLI implementation
-│       └── operator.py       # Kopf operator logic
-├── tests/
-│   ├── __init__.py
-│   ├── conftest.py          # Pytest fixtures
-│   ├── test_operator_integration.py  # Unit tests with mocked K8s
-│   └── test_e2e.py          # End-to-end tests (requires cluster)
-├── pyproject.toml            # Python project configuration (uv)
-├── uv.lock                   # Locked dependencies
-├── pytest.ini                # Pytest configuration
-├── Taskfile.yml              # Task automation
-├── Dockerfile                # Container image definition
-├── .gitignore                # Git ignore rules
-└── README.md                 # This file
+
+See the [Helm chart README](helm/vcluster-argocd-enroller/README.md) for the full list of configurable parameters, HA setup, network policies, and monitoring options.
+
+## CLI
+
+The operator also provides CLI subcommands for manual management:
+
+- **`check`** -- Show vCluster enrollment status across namespaces
+- **`enroll <name> <namespace>`** -- Manually enroll a vCluster in ArgoCD
+- **`unenroll <name> --confirm`** -- Remove a vCluster from ArgoCD
+
+## Troubleshooting
+
+**Check operator logs:**
+
+```bash
+kubectl logs -l app.kubernetes.io/name=vcluster-argocd-enroller -n vcluster-system
 ```
+
+**Verify RBAC permissions:**
+
+```bash
+kubectl auth can-i get secrets \
+  --as=system:serviceaccount:vcluster-system:vcluster-argocd-enroller \
+  -n vcluster-system
+
+kubectl auth can-i create secrets \
+  --as=system:serviceaccount:vcluster-system:vcluster-argocd-enroller \
+  -n argocd
+```
+
+**Enable debug logging:**
+
+```bash
+helm upgrade vcluster-argocd-enroller \
+  oci://ghcr.io/andrewrothstein/charts/vcluster-argocd-enroller \
+  --namespace vcluster-system \
+  --reuse-values \
+  --set operator.logLevel=DEBUG
+```
+
+## Links
+
+- [BUILDING.md](BUILDING.md) -- Developer guide (building, testing, project structure)
+- [Helm Chart README](helm/vcluster-argocd-enroller/README.md) -- Full chart configuration reference
+- [Issues](https://github.com/andrewrothstein/vcluster-argocd-enroller/issues) -- Bug reports and feature requests

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Key Helm values:
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `operator.argoCDNamespace` | ArgoCD namespace | `argocd` |
-| `operator.vclusterNamespace` | Namespace for vCluster instances | `vcluster-system` |
+| `operator.vclusterNamespace` | Namespace where the operator is deployed (vClusters are watched cluster-wide) | `vcluster-system` |
 | `operator.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
 | `resources.requests.cpu` | CPU request | `100m` |
 | `resources.requests.memory` | Memory request | `128Mi` |

--- a/helm/vcluster-argocd-enroller/README.md
+++ b/helm/vcluster-argocd-enroller/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters and their default values:
 | `resources.limits.memory` | Memory limit | `256Mi` |
 | `resources.requests.cpu` | CPU request | `100m` |
 | `resources.requests.memory` | Memory request | `128Mi` |
-| `operator.vclusterNamespace` | Namespace for vCluster instances | `vcluster-system` |
+| `operator.vclusterNamespace` | Namespace where the operator is deployed (vClusters are watched cluster-wide) | `vcluster-system` |
 | `operator.argoCDNamespace` | ArgoCD namespace | `argocd` |
 | `operator.logLevel` | Log level (DEBUG, INFO, WARNING, ERROR) | `INFO` |
 | `operator.useEmbeddedCode` | Use embedded operator code | `true` |


### PR DESCRIPTION
## Summary
- Renamed existing developer-focused `README.md` to `BUILDING.md` (content preserved)
- Created new user-oriented `README.md` with badges, quick start Helm install from OCI registry, configuration table, CLI summary, troubleshooting, and links to detailed docs

## Test plan
- [ ] Verify `BUILDING.md` content matches original README (only project structure tree updated)
- [ ] Verify new `README.md` renders correctly on GitHub
- [ ] `task helm-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)