### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vcluster-argocd-enroller"
-version = "1.0.0"
+version = "1.1.0"
 description = "Kubernetes operator that automatically enrolls vCluster instances in ArgoCD"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/vcluster_argocd_enroller/__init__.py
+++ b/src/vcluster_argocd_enroller/__init__.py
@@ -1,3 +1,3 @@
 """vCluster ArgoCD Enroller - Kubernetes operator for automatic vCluster enrollment in ArgoCD."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "vcluster-argocd-enroller"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## Summary

Maintenance release rolling up chore work since 1.0.0:

- Pin GitHub Actions to SHAs; bump majors (#19)
- Bump runtime deps: cyclopts v2→v4, rich v13→v15 (#26)
- Bump dev tooling: mypy, ruff, pytest-cov (#26)
- Bump kubernetes client v31→v35, pytest v8→v9, kopf minor (#27)
- Switch Docker base image from bookworm-slim to trixie-slim (#27)

No user-facing operator API changes; minor bump signals the runtime dep majors.

`Chart.yaml` is rewritten by the release workflow at tag time, so it's intentionally left on 1.0.0 here.

## Test plan
- [ ] CI passes
- [ ] After merge, tag `v1.1.0` on main to trigger release workflow (multi-arch image + helm OCI push + GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)