### PR TITLE
fix(helm): grant patch/update on statefulsets for kopf finalizers

### DIFF
--- a/helm/vcluster-argocd-enroller/templates/clusterrole.yaml
+++ b/helm/vcluster-argocd-enroller/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch"]


### PR DESCRIPTION
## Summary

- Adds `patch` and `update` verbs to the chart's ClusterRole rule for `apps/statefulsets`.
- The operator registers a `@kopf.on.delete` handler on StatefulSets (`src/vcluster_argocd_enroller/operator.py:167`); kopf implements deletion handlers via finalizers, which it installs and removes by `PATCH`-ing the watched resource. With the prior `get/list/watch`-only rule, kopf could not manage its finalizer and deleted vCluster StatefulSets would get stuck `Terminating`.

Closes #33

## Test plan

- [ ] `task helm-lint` passes locally
- [ ] `task helm-template` renders the updated rule
- [ ] In a k3d cluster: install the chart, create a StatefulSet labeled `app=vcluster`, delete it, and confirm it terminates cleanly (no stuck finalizer) and the corresponding `vcluster-{name}` ArgoCD secret is removed
- [ ] CI integration test still green

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ)_