### PR TITLE
chore(release): bump version to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vcluster-argocd-enroller"
-version = "1.1.0"
+version = "1.1.1"
 description = "Kubernetes operator that automatically enrolls vCluster instances in ArgoCD"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/vcluster_argocd_enroller/__init__.py
+++ b/src/vcluster_argocd_enroller/__init__.py
@@ -1,3 +1,3 @@
 """vCluster ArgoCD Enroller - Kubernetes operator for automatic vCluster enrollment in ArgoCD."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "vcluster-argocd-enroller"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## Summary

- Bumps version to `1.1.1` in `__init__.py`, `pyproject.toml`, and `uv.lock`.
- Patch release shipping the chart RBAC fix from #34: kopf can now manage finalizers on labeled vCluster StatefulSets, so deletes complete cleanly.

Once merged, tag `v1.1.1` to trigger `release.yaml` (multi-arch image to ghcr.io + Helm chart packaged to `oci://ghcr.io/.../charts/`).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `git tag v1.1.1 <merge-sha> && git push origin v1.1.1`
- [ ] Confirm release workflow publishes the image and chart

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ)_