### PR TITLE
docs(claude): require fetch from origin before starting a new PR branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,10 @@ bd close <id>         # Complete work
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
+## Branch Workflow
+
+When starting a new PR branch, always run `git fetch origin` first and create the branch from the up-to-date `origin/main` (or the relevant upstream). Do not branch from a stale local ref.
+
 ## Session Completion
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.


### PR DESCRIPTION
Captures the rule that new feature/release/docs branches must be created
from an up-to-date origin/main rather than a stale local ref.

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ