### PR TITLE
chore(security): pin base image, default-on NetworkPolicy, frozen deps, redacted error logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras
+          uv sync --all-extras --frozen
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # ratchet:pre-commit/action@v3.0.1
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras
+          uv sync --all-extras --frozen
 
       - name: Run tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - build the wheel using uv
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim@sha256:edcb5e3c5a6a4960e7e871ac428c2d9bf575021835af47f26ec057c637849ac0 AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ COPY src/ ./src/
 RUN uv build --wheel --out-dir /dist
 
 # Runtime stage - use uv base image
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim@sha256:edcb5e3c5a6a4960e7e871ac428c2d9bf575021835af47f26ec057c637849ac0
 
 LABEL org.opencontainers.image.title="vcluster-argocd-enroller"
 LABEL org.opencontainers.image.description="Kubernetes operator that automatically enrolls vCluster instances in ArgoCD"

--- a/helm/vcluster-argocd-enroller/values.yaml
+++ b/helm/vcluster-argocd-enroller/values.yaml
@@ -122,7 +122,7 @@ rbac:
 # Network policy configuration
 networkPolicy:
   # Enable network policy
-  enabled: false
+  enabled: true
 
   # Ingress rules
   ingress: []

--- a/src/vcluster_argocd_enroller/operator.py
+++ b/src/vcluster_argocd_enroller/operator.py
@@ -105,8 +105,11 @@ def handle_vcluster_enrollment(statefulset_name: str, namespace: str, **kwargs):
     try:
         vc_secret = core_v1_api.read_namespaced_secret(name=vcluster_secret_name, namespace=namespace)
     except ApiException as e:
-        logger.error(f"API error reading vcluster secret {namespace}/{vcluster_secret_name}: {e}")
-        raise kopf.TemporaryError(f"Failed to read vcluster secret {namespace}/{vcluster_secret_name}: {e}", delay=60)
+        logger.error(f"API error reading vcluster secret {namespace}/{vcluster_secret_name}: {e.status} {e.reason}")
+        raise kopf.TemporaryError(
+            f"Failed to read vcluster secret {namespace}/{vcluster_secret_name}: {e.status} {e.reason}",
+            delay=60,
+        )
     except Exception as e:
         logger.error(f"Failed to read vcluster secret {namespace}/{vcluster_secret_name}: {e}")
         raise kopf.PermanentError(f"Failed to read vcluster secret: {e}")
@@ -129,8 +132,8 @@ def handle_vcluster_enrollment(statefulset_name: str, namespace: str, **kwargs):
             core_v1_api.replace_namespaced_secret(argocd_secret_name, ARGOCD_NAMESPACE, secret_body)
             logger.info(f"Updated ArgoCD cluster secret {argocd_secret_name} for vcluster {vcluster_name}")
         else:
-            logger.error(f"API error creating ArgoCD secret {argocd_secret_name}: {e}")
-            raise kopf.TemporaryError(f"Failed to create ArgoCD secret: {e}", delay=60)
+            logger.error(f"API error creating ArgoCD secret {argocd_secret_name}: {e.status} {e.reason}")
+            raise kopf.TemporaryError(f"Failed to create ArgoCD secret: {e.status} {e.reason}", delay=60)
 
     return {"status": "Success"}
 
@@ -184,9 +187,9 @@ def vcluster_deleted(name, namespace, **kwargs):
         if e.status == 404:
             logger.info(f"ArgoCD secret {argocd_secret_name} not found, already deleted")
         else:
-            logger.error(f"Failed to delete ArgoCD cluster secret {argocd_secret_name}: {e}")
+            logger.error(f"Failed to delete ArgoCD cluster secret {argocd_secret_name}: {e.status} {e.reason}")
             # Don't raise PermanentError on deletion - allow finalizer removal
-            return {"status": "Failed", "message": str(e)}
+            return {"status": "Failed", "message": f"{e.status} {e.reason}"}
     except Exception as e:
         logger.error(f"Failed to remove vcluster {namespace}/{vcluster_name} from ArgoCD: {e}")
         # Don't raise PermanentError on deletion - allow finalizer removal


### PR DESCRIPTION
## Summary

Bundle of four small security hardening changes from the repo audit. Each is mechanical and uncontroversial; bundling them avoids four separate review cycles. The bigger RBAC split (cluster-wide read + namespaced write) is intentionally left out — it deserves its own PR.

### Changes

- **`Dockerfile`** — Pin `ghcr.io/astral-sh/uv:python3.13-trixie-slim` to digest `sha256:edcb5e3c…` in both build and runtime stages. The tag itself is unchanged; future upstream tag updates can no longer silently swap the base layer. Bumping is now an explicit commit.
- **`helm/.../values.yaml`** — Default `networkPolicy.enabled` to `true`. The chart already ships ingress/egress templates that allow DNS + kube-apiserver; flipping the default closes the unauthenticated `/healthz` exposure for default installs while preserving all needed egress.
- **`.github/workflows/ci.yaml`** — Add `--frozen` to both `uv sync --all-extras` invocations. CI now fails fast if `pyproject.toml` and `uv.lock` drift instead of picking up newer versions silently. Combined with the existing committed `uv.lock`, runtime deps are effectively pinned.
- **`src/.../operator.py`** — Replace `f"...: {e}"` / `str(e)` with `f"... {e.status} {e.reason}"` for `kubernetes.client.rest.ApiException`. The K8s client's `__str__` includes the response body; redacting to status+reason avoids accidentally surfacing API payload data in pod logs. Bare `Exception` blocks unchanged.

## Verification

- [x] `uv sync --all-extras --frozen` succeeds locally (no lock drift)
- [x] `uv run pytest tests/ -v -m "not e2e"` — 13 passed, 6 deselected
- [x] `uv run ruff check` clean; `ruff format` applied
- [ ] CI green on this PR (Trivy will rescan the digest-pinned image)
- [ ] Manual: install chart with defaults in a k3d cluster, confirm operator pod still reaches the K8s API and processes a labeled vCluster StatefulSet through to ArgoCD secret creation

## Out of scope

- RBAC split (Critical finding): cluster-wide secret write/delete should be narrowed to a namespaced Role on the ArgoCD namespace. Will follow as its own PR.
- Configurable watched namespaces (Medium): design call deferred.

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ)_