### PR TITLE
fix(helm)!: split RBAC — cluster-wide secret read, namespaced write

### DIFF
--- a/helm/vcluster-argocd-enroller/templates/clusterrole.yaml
+++ b/helm/vcluster-argocd-enroller/templates/clusterrole.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     {{- include "vcluster-argocd-enroller.labels" . | nindent 4 }}
 rules:
+# Read vCluster-generated `vc-{name}` secrets cluster-wide. Write access to
+# secrets is granted via a namespaced Role in the ArgoCD namespace, not here.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs: ["get", "list", "watch", "patch", "update"]

--- a/helm/vcluster-argocd-enroller/templates/role.yaml
+++ b/helm/vcluster-argocd-enroller/templates/role.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "vcluster-argocd-enroller.fullname" . }}
+  namespace: {{ include "vcluster-argocd-enroller.argoCDNamespace" . }}
+  labels:
+    {{- include "vcluster-argocd-enroller.labels" . | nindent 4 }}
+rules:
+# Write the per-vCluster cluster secret only in the ArgoCD namespace.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "update", "patch", "delete"]
+{{- end }}

--- a/helm/vcluster-argocd-enroller/templates/rolebinding.yaml
+++ b/helm/vcluster-argocd-enroller/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "vcluster-argocd-enroller.fullname" . }}
+  namespace: {{ include "vcluster-argocd-enroller.argoCDNamespace" . }}
+  labels:
+    {{- include "vcluster-argocd-enroller.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vcluster-argocd-enroller.serviceAccountName" . }}
+  namespace: {{ include "vcluster-argocd-enroller.vclusterNamespace" . }}
+roleRef:
+  kind: Role
+  name: {{ include "vcluster-argocd-enroller.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
## Summary

Resolves the Critical finding from the audit: the operator's ServiceAccount could `create/update/patch/delete` **any secret in any namespace**, far broader than needed.

### What it now has

- **ClusterRole** (cluster-wide) — `secrets: get/list/watch` only. Required to read `vc-{name}` secrets from arbitrary vCluster namespaces.
- **Role** in `operator.argoCDNamespace` (new, `templates/role.yaml`) — `secrets: create/update/patch/delete`. The single namespace the operator actually writes to.
- **RoleBinding** in `operator.argoCDNamespace` (new, `templates/rolebinding.yaml`) — binds the operator ServiceAccount (which lives in `operator.vclusterNamespace`) to the new Role.

`statefulsets` (cluster-wide get/list/watch/patch/update for kopf finalizers) and `events` rules are unchanged.

### Operator code impact

None. The operator's K8s calls are:
- `read_namespaced_secret(vc-{name}, src_ns)` — covered by cluster-wide `get`.
- `create_namespaced_secret(ARGOCD_NAMESPACE, …)` — covered by the new Role's `create`.
- `replace_namespaced_secret(name, ARGOCD_NAMESPACE, …)` — covered by `update`.
- `delete_namespaced_secret(name, ARGOCD_NAMESPACE)` — covered by `delete`.

### Breaking-change marker

Marked `fix(helm)!` because anyone running with `rbac.create: false` and supplying their own ClusterRole will now also need a namespaced Role in the ArgoCD namespace. **The default install path (`rbac.create: true`) is unaffected** — Helm will create the new Role/RoleBinding automatically. Worth a release note in the next version.

### Prerequisite

The ArgoCD namespace (default `argocd`) must already exist when the chart is installed, since the Role/RoleBinding live in it. This was already an effective prerequisite (the operator wrote secrets there) but is now explicit at install time.

## Verification

- [x] `uv run pytest tests/ -v -m "not e2e"` — 13 passed (RBAC isn't exercised by unit tests; mocks bypass it)
- [ ] CI: helm-lint + kubeconform validation should pass
- [ ] CI: the k3d integration test exercises a real cluster install — this is the actual RBAC verification
- [ ] Manual smoke after merge: install in k3d, confirm a labeled vCluster StatefulSet still produces an ArgoCD secret and is cleanly removed on delete

## Follow-ups (out of scope)

- Configurable watched namespaces (Medium) — narrow the StatefulSet watch to a configurable list.
- Bump chart minor version + add release notes prior to the next tag.

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ)_