### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vcluster-argocd-enroller"
-version = "1.1.1"
+version = "1.2.0"
 description = "Kubernetes operator that automatically enrolls vCluster instances in ArgoCD"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/vcluster_argocd_enroller/__init__.py
+++ b/src/vcluster_argocd_enroller/__init__.py
@@ -1,3 +1,3 @@
 """vCluster ArgoCD Enroller - Kubernetes operator for automatic vCluster enrollment in ArgoCD."""
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "vcluster-argocd-enroller"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## Summary

Bumps version to `1.2.0` in `__init__.py`, `pyproject.toml`, and `uv.lock`. Minor bump (not patch) because PR #39 included a `fix!` marker for `rbac.create: false` users with custom-supplied ClusterRoles.

### What ships in 1.2.0

- **#34** — `fix(helm)`: grant `patch`/`update` on statefulsets so kopf can install/remove finalizers (deletion handler now works).
- **#38** — `chore(security)`: pin uv base image to digest, default-on `networkPolicy.enabled`, `--frozen` on `uv sync`, redact `ApiException.body` from error logs.
- **#39** — `fix(helm)!`: split RBAC. ClusterRole now only grants `secrets: get/list/watch`; new namespaced Role grants `create/update/patch/delete` on secrets in `operator.argoCDNamespace`. **Breaking only for installs that disable `rbac.create` and supply their own ClusterRole.**

### Branch naming

I tried `release/v1.2.0` first; the remote rejected it (looks like `release/*` has a push-protection rule). Re-pushed as `chore/release-1-2-0` — same content, different branch name.

## After merge

Tag `v1.2.0` from a local clone (this sandbox can't push tags) to trigger `release.yaml`:

```
git fetch origin
git tag -a v1.2.0 -m "Release v1.2.0" <merge-sha>
git push origin v1.2.0
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag `v1.2.0` and confirm `release.yaml` publishes the multi-arch image and the Helm chart to `oci://ghcr.io/.../charts/`
- [ ] Smoke install in k3d with the published chart

https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016N4UPGg1B9o6BhhZHF6mnQ)_